### PR TITLE
Fix circular import in loader

### DIFF
--- a/KnowBloom/client/src/components/KnowBloomLoader.jsx
+++ b/KnowBloom/client/src/components/KnowBloomLoader.jsx
@@ -1,4 +1,4 @@
-import LogoKnowBloom from "./KnowBloomLoader";
+import LogoKnowBloom from "./LogoKnowBloom.jsx";
 
 const KnowBloomLoader = () => (
   <div


### PR DESCRIPTION
## Summary
- fix circular import in `KnowBloomLoader.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849bea9c1ac8329a325ceb68070ee73