### PR TITLE
Add express-session dependency

### DIFF
--- a/KnowBloom/server/package.json
+++ b/KnowBloom/server/package.json
@@ -29,6 +29,7 @@
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "pdfkit": "^0.17.1",
-    "stripe": "^18.2.0"
+    "stripe": "^18.2.0",
+    "express-session": "^1.17.3"
   }
 }


### PR DESCRIPTION
## Summary
- add `express-session` dependency in server package

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849bea65b3083299ab81e9698fb4f17