### PR TITLE
Fix production login issues

### DIFF
--- a/KnowBloom/client/src/features/api/authApi.js
+++ b/KnowBloom/client/src/features/api/authApi.js
@@ -2,7 +2,9 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { userLoggedIn, userLoggedOut } from "../authSlice";
 
-const USER_API = "http://localhost:8080/api/v1/user"; // remove trailing slash
+// Base URL for user-related APIs. Falls back to relative path if env not set.
+const USER_API =
+  import.meta.env.VITE_USER_API || "/api/v1/user";
 
 export const authApi = createApi({
   reducerPath: "authApi",

--- a/KnowBloom/server/package.json
+++ b/KnowBloom/server/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon index.js",
-    "start": "node app.js"
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",

--- a/KnowBloom/server/utils/generateToken.js
+++ b/KnowBloom/server/utils/generateToken.js
@@ -9,7 +9,8 @@ export const generateToken = (res, user, message) => {
     .status(200)
     .cookie("token", token, {
       httpOnly: true,
-      sameSite: "strict",
+      sameSite: "none",
+      secure: true,
       maxAge: 24 * 60 * 60 * 1000, // 1 day
     })
     .json({


### PR DESCRIPTION
## Summary
- use env var for USER_API base URL
- adjust cookie options for cross-site auth
- correct server start script

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684aaad07e248329b716652a1403da3b