### PR TITLE
Fix dark mode toggle logic

### DIFF
--- a/client/src/DarkMode.jsx
+++ b/client/src/DarkMode.jsx
@@ -3,10 +3,6 @@ import React from "react";
 import { useTheme } from "./components/ThemeProvider";
 import { Sun, Moon } from "lucide-react";
 
-const themes = ["light", "dark", "system"];
-const getNextTheme = (current) =>
-  themes[(themes.indexOf(current) + 1) % themes.length];
-
 const useCurrentThemeClass = () => {
   const [current, setCurrent] = React.useState(() =>
     document.documentElement.classList.contains("dark") ? "dark" : "light"
@@ -31,12 +27,11 @@ const useCurrentThemeClass = () => {
 };
 
 const DarkModeToggle = () => {
-  const { theme, setTheme } = useTheme();
+  const { setTheme } = useTheme();
   const actualTheme = useCurrentThemeClass();
 
   const handleToggle = () => {
-    const nextTheme = getNextTheme(theme);
-    setTheme(nextTheme);
+    setTheme(actualTheme === "dark" ? "light" : "dark");
   };
 
   return (


### PR DESCRIPTION
## Summary
- fix logic for DarkMode toggle so theme switches with one click

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ad8ff039c8329afe11b173fd8ab95