### PR TITLE
Validate all course fields before saving

### DIFF
--- a/client/src/pages/instructor/course/CourseTab.jsx
+++ b/client/src/pages/instructor/course/CourseTab.jsx
@@ -149,8 +149,21 @@ const CourseTab = () => {
   };
 
   const saveChanges = async () => {
-    if (!form.courseTitle.trim() || !form.description.trim()) {
-      toast.error("Title and description are required.");
+    const hasEmptyLearn = form.whatYouWillLearn.some((i) => !i.trim());
+    const hasEmptyPrior = form.priorRequirements.some((i) => !i.trim());
+
+    if (
+      !form.courseTitle.trim() ||
+      !form.subTitle.trim() ||
+      !form.description.trim() ||
+      !form.category.trim() ||
+      !form.courseLevel.trim() ||
+      form.coursePrice === "" ||
+      (!form.courseThumbnail && !preview) ||
+      hasEmptyLearn ||
+      hasEmptyPrior
+    ) {
+      toast.error("Please fill all fields.");
       return;
     }
     const formData = new FormData();


### PR DESCRIPTION
## Summary
- add comprehensive validation of form fields when saving an instructor's course

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad9f4032c832999c56061654cbeab