### PR TITLE
Use system theme by default

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -132,7 +132,7 @@ const appRouter = createBrowserRouter([
 
 function App() {
   return (
-    <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
+    <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
       <RouterProvider router={appRouter} />
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary
- set the `ThemeProvider` in `App.jsx` to pick up the system theme instead of forcing light mode

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684adbb3bf3c8329a9cb61c96d198122