### PR TITLE
Improve QuizViewer warnings

### DIFF
--- a/client/src/pages/instructor/quiz/QuizViewer.jsx
+++ b/client/src/pages/instructor/quiz/QuizViewer.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { toast } from "react-hot-toast";
 import { useGetLectureQuizQuery } from "@/features/api/courseApi";
 
 export default function QuizViewer({
@@ -139,7 +140,7 @@ export default function QuizViewer({
   const handleSubmit = () => {
     // ensure every question has an answer
     if (selectedAnswers.some((ans) => ans < 0)) {
-      alert("Please answer all questions before submitting.");
+      toast.error("Please answer all questions before submitting.");
       return;
     }
     // compute score


### PR DESCRIPTION
## Summary
- replace `alert()` with a toast notification in QuizViewer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ae110bd74832989e4a0a1c7d918cd