### PR TITLE
Improve course card skeleton

### DIFF
--- a/client/src/components/CourseSkeleton.jsx
+++ b/client/src/components/CourseSkeleton.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const CourseSkeleton = () => {
+  return (
+    <div className="overflow-hidden aspect-[1/1] w-full max-w-xs flex flex-col rounded-2xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 shadow-sm animate-pulse">
+      <div className="aspect-[1.7/1] w-full bg-gray-300 dark:bg-gray-700" />
+      <div className="flex flex-col flex-1 justify-between px-4 pt-2 pb-3 space-y-3">
+        <div className="h-5 w-3/4 bg-gray-300 dark:bg-gray-700 rounded" />
+        <div className="flex items-center gap-2">
+          <div className="h-6 w-6 bg-gray-300 dark:bg-gray-700 rounded-full" />
+          <div className="h-4 w-20 bg-gray-300 dark:bg-gray-700 rounded" />
+        </div>
+        <div className="flex items-center justify-between border-t border-gray-200 dark:border-gray-700 pt-2 mt-auto">
+          <div className="h-6 w-12 bg-gray-300 dark:bg-gray-700 rounded" />
+          <div className="h-7 w-20 bg-gray-300 dark:bg-gray-700 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CourseSkeleton;

--- a/client/src/pages/student/Courses.jsx
+++ b/client/src/pages/student/Courses.jsx
@@ -1,7 +1,7 @@
-import { Skeleton } from "@/components/ui/skeleton";
 import React from "react";
 import Course from "./Course";
 import { useGetPublishedCourseQuery } from "@/features/api/courseApi";
+import CourseSkeleton from "@/components/CourseSkeleton";
 
 const Courses = () => {
   const { data, isLoading, isError } = useGetPublishedCourseQuery();
@@ -28,22 +28,3 @@ const Courses = () => {
 };
 
 export default Courses;
-
-const CourseSkeleton = () => {
-  return (
-    <div className="bg-white shadow-md hover:shadow-lg transition-shadow rounded-lg overflow-hidden">
-      <Skeleton className="w-full h-36" />
-      <div className="px-5 py-4 space-y-3">
-        <Skeleton className="h-6 w-3/4" />
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Skeleton className="h-6 w-6 rounded-full" />
-            <Skeleton className="h-4 w-20" />
-          </div>
-          <Skeleton className="h-4 w-16" />
-        </div>
-        <Skeleton className="h-4 w-1/4" />
-      </div>
-    </div>
-  );
-};


### PR DESCRIPTION
## Summary
- add a reusable `CourseSkeleton` component to mimic the course card
- use the new skeleton in `Courses` page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ae397eef88329a846960c11299376