### PR TITLE
Add OTP verification on email update

### DIFF
--- a/client/src/features/api/authApi.js
+++ b/client/src/features/api/authApi.js
@@ -93,6 +93,13 @@ export const authApi = createApi({
         body: { email, otp },
       }),
     }),
+    verifyEmailChange: builder.mutation({
+      query: ({ email, otp }) => ({
+        url: "verify-email-change",
+        method: "POST",
+        body: { email, otp },
+      }),
+    }),
     forgotPassword: builder.mutation({
       query: ({ email }) => ({
         url: "forgot-password", // remove leading slash
@@ -130,6 +137,7 @@ export const {
   useUpdatePasswordUserMutation,
   useGetInstructorByIdQuery,
   useVerifyOtpMutation,
+  useVerifyEmailChangeMutation,
   useForgotPasswordMutation,
   useResetPasswordMutation,
   useGetUserByNameQuery,

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -8,6 +8,7 @@ import {
   updatePassword,
   checkCurrentPassword,
   verifyOtp,
+  verifyEmailChange,
   forgotPassword,
   resetPassword,
   getUserByUsername,
@@ -36,6 +37,7 @@ router.put(
 router.put("/update-password", isAuthenticated, updatePassword);
 router.post("/check-password", isAuthenticated, checkCurrentPassword);
 router.post("/verify-otp", verifyOtp);
+router.post("/verify-email-change", isAuthenticated, verifyEmailChange);
 
 // Google Auth
 router.get(


### PR DESCRIPTION
## Summary
- send OTP when email is changed in profile update
- verify OTP for email update via new endpoint
- expose verifyEmailChange API client
- prompt for OTP when user updates email

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ae9ac4668832981a94e82747cf783