### PR TITLE
Disable OTP verify after timer expires

### DIFF
--- a/client/src/components/EditProfile.jsx
+++ b/client/src/components/EditProfile.jsx
@@ -230,6 +230,7 @@ const Profile = () => {
   const handleResendOtp = async () => {
     setOtpError("");
     setEmailCountdown(30);
+    setEmailOtp("");
     await updateUser({ email: pendingEmail }).unwrap();
   };
 
@@ -537,7 +538,11 @@ const Profile = () => {
             </Button>
             <Button
               onClick={handleVerifyEmailOtp}
-              disabled={verifyEmailLoading || emailOtp.trim().length < 6}
+              disabled={
+                verifyEmailLoading ||
+                emailOtp.trim().length < 6 ||
+                emailCountdown <= 0
+              }
             >
               {verifyEmailLoading ? "Verifying…" : "Verify OTP"}
             </Button>

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -171,6 +171,7 @@ const Login = () => {
     setOtpError("");
     setCanResend(false);
     setCountdown(30);
+    setOtp("");
     await handleRegistration("signup");
   };
 
@@ -335,7 +336,9 @@ const Login = () => {
                       </AlertDialogCancel>
                       <Button
                         onClick={handleOtpVerify}
-                        disabled={otpIsLoading || otp.trim().length < 6}
+                        disabled={
+                          otpIsLoading || otp.trim().length < 6 || countdown <= 0
+                        }
                       >
                         {otpIsLoading ? <>Verifying…</> : "Verify OTP"}
                       </Button>


### PR DESCRIPTION
## Summary
- disable Verify OTP button if timer hits zero
- clear OTP input when resending
- apply same logic on EditProfile OTP flow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684afb77783c8329b4afd91d725abd62