### PR TITLE
Add license field

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -65,5 +65,6 @@
   },
   "engines": {
     "node": ">=20"
-  }
+  },
+  "license": "ISC"
 }


### PR DESCRIPTION
## Summary
- add "license" to client package.json so it references the repo license

## Testing
- `npm test` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684b324acaa48329a0aedbd721a94dca