### PR TITLE
Fix isGuest middleware

### DIFF
--- a/server/middlewares/isGuest.js
+++ b/server/middlewares/isGuest.js
@@ -1,12 +1,3 @@
-const isGuest = (req, res, next) => {
-  const token = req.cookies.token;
-
-  if (token) {
-    return res.status(403).json({ message: "Already logged in." });
-  }
-
-  next();
-
 import jwt from "jsonwebtoken";
 import dotenv from "dotenv";
 
@@ -31,7 +22,6 @@ const isGuest = (req, res, next) => {
     });
     next();
   }
->>>>>>> e0bb359b91c4b7263b1c50098be3c68aee652981
 };
 
 export default isGuest;


### PR DESCRIPTION
## Summary
- clean up server/middlewares/isGuest.js
- remove duplicate definitions and stale merge markers
- keep token verification and cookie clearing logic

## Testing
- `npm test` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684b3251d26c832988681ece56f255da