### PR TITLE
Fix isGuest test URL scheme

### DIFF
--- a/server/test/isGuest.test.js
+++ b/server/test/isGuest.test.js
@@ -19,7 +19,7 @@ test('login succeeds when stale token cookie is present', async () => {
   const server = app.listen(0);
   const { port } = server.address();
 
-  const response = await fetch(`https://127.0.0.1:${port}/login`, {
+  const response = await fetch(`http://127.0.0.1:${port}/login`, {
     method: 'POST',
     headers: { Cookie: 'token=staletoken' },
   });


### PR DESCRIPTION
## Summary
- use `http` instead of `https` for the test server in `isGuest.test.js`

## Testing
- `npm test` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684d46b43e5c8329966c89c4fcb479e7