### PR TITLE
Import crypto for Razorpay webhook

### DIFF
--- a/server/controllers/coursePurchase.controller.js
+++ b/server/controllers/coursePurchase.controller.js
@@ -9,6 +9,7 @@ import dotenv from "dotenv";
 import { Module } from "../models/module.model.js";
 import { sendPurchaseConfirmationEmail } from "../utils/email.js";
 import Razorpay from "razorpay";
+import crypto from "crypto";
 
 const razorpay = new Razorpay({
   key_id: process.env.RAZORPAY_KEY_ID,


### PR DESCRIPTION
## Summary
- import Node's crypto module in `coursePurchase.controller.js`
- use this module to validate Razorpay webhook signatures

## Testing
- `npm --prefix server test` *(fails: cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684d46b3eee0832989a8769ea6635bbc