### PR TITLE
Check Razorpay credentials before creating instance

### DIFF
--- a/server/controllers/coursePurchase.controller.js
+++ b/server/controllers/coursePurchase.controller.js
@@ -10,11 +10,6 @@ import { Module } from "../models/module.model.js";
 import { sendPurchaseConfirmationEmail } from "../utils/email.js";
 import Razorpay from "razorpay";
 
-const razorpay = new Razorpay({
-  key_id: process.env.RAZORPAY_KEY_ID,
-  key_secret: process.env.RAZORPAY_SECRET,
-});
-
 dotenv.config();
 
 // Ensure STRIPE_SECRET_KEY is provided
@@ -117,6 +112,21 @@ export const createCheckoutSession = async (req, res) => {
     if (!courseId) {
       return res.status(400).json({ message: "courseId is required" });
     }
+
+    const { RAZORPAY_KEY_ID, RAZORPAY_SECRET } = process.env;
+    if (!RAZORPAY_KEY_ID || !RAZORPAY_SECRET) {
+      console.error(
+        "Razorpay credentials missing: RAZORPAY_KEY_ID or RAZORPAY_SECRET"
+      );
+      return res
+        .status(500)
+        .json({ message: "Payment configuration is not properly set." });
+    }
+
+    const razorpay = new Razorpay({
+      key_id: RAZORPAY_KEY_ID,
+      key_secret: RAZORPAY_SECRET,
+    });
 
     const course = await Course.findById(courseId).lean();
     if (!course) {


### PR DESCRIPTION
## Summary
- load env vars earlier in `coursePurchase.controller`
- validate Razorpay credentials when creating a checkout session
- instantiate Razorpay client only if credentials are present

## Testing
- `npm test --silent --prefix server` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684d46b2b8c483299884d7638bfae063