### PR TITLE
Remove leftover console.log statements

### DIFF
--- a/server/controllers/coursePurchase.controller.js
+++ b/server/controllers/coursePurchase.controller.js
@@ -185,7 +185,6 @@ export const createCheckoutSession = async (req, res) => {
 
 //   // Only handle checkout.session.completed
 //   if (event.type === "checkout.session.completed") {
-//     console.log("stripeWebhook: checkout.session.completed");
 
 //     try {
 //       const session = event.data.object;
@@ -249,7 +248,6 @@ export const createCheckoutSession = async (req, res) => {
 //             invoiceNumber,
 //             purchaseDate,
 //           });
-//           console.log(`Purchase email sent to ${toEmail}`);
 //         } else {
 //           console.warn(
 //             "Page not found or missing email; cannot send invoice email."
@@ -345,7 +343,6 @@ export const getCourseDetailWithPurchaseStatus = async (req, res) => {
   try {
     const { courseId } = req.params;
     const userId = req.id;
-    console.log("Requested courseId:", courseId, "by userId:", userId);
 
     // 1. Fetch course document (with creator info)
     const courseDoc = await Course.findById(courseId)
@@ -353,7 +350,7 @@ export const getCourseDetailWithPurchaseStatus = async (req, res) => {
       .lean();
 
     if (!courseDoc) {
-      console.log("Course not found!");
+      console.error("Course not found!");
       return res.status(404).json({ message: "Course not found!" });
     }
 
@@ -367,7 +364,7 @@ export const getCourseDetailWithPurchaseStatus = async (req, res) => {
         })
         .lean();
     } catch (err) {
-      console.log("Error populating modules/lectures:", err);
+      console.error("Error populating modules/lectures:", err);
       modules = [];
     }
 
@@ -382,7 +379,7 @@ export const getCourseDetailWithPurchaseStatus = async (req, res) => {
           .lean();
       }
     } catch (err) {
-      console.log("Error fetching legacy lectures:", err);
+      console.error("Error fetching legacy lectures:", err);
       legacyLectureDocs = [];
     }
 
@@ -405,7 +402,7 @@ export const getCourseDetailWithPurchaseStatus = async (req, res) => {
         status: "completed",
       });
     } catch (err) {
-      console.log("Error counting enrollments:", err);
+      console.error("Error counting enrollments:", err);
       enrolledCount = 0;
     }
 

--- a/server/controllers/module.controller.js
+++ b/server/controllers/module.controller.js
@@ -29,11 +29,11 @@ export const createModule = async (req, res) => {
     return res
       .status(201)
       .json({ module, message: "Module created successfully." });
-  } catch (error) {
-    console.log(error);
-    return res.status(500).json({ message: "Failed to create module" });
-  }
-};
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Failed to create module" });
+    }
+  };
 
 export const getCourseModules = async (req, res) => {
   try {
@@ -42,7 +42,7 @@ export const getCourseModules = async (req, res) => {
     if (!course) return res.status(404).json({ message: "Course not found" });
     return res.status(200).json({ modules: course.modules });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     return res.status(500).json({ message: "Failed to get modules" });
   }
 };
@@ -53,11 +53,11 @@ export const getModuleById = async (req, res) => {
     const module = await Module.findById(moduleId);
     if (!module) return res.status(404).json({ message: "Module not found" });
     return res.status(200).json({ module });
-  } catch (error) {
-    console.log(error);
-    return res.status(500).json({ message: "Failed to get module" });
-  }
-};
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Failed to get module" });
+    }
+  };
 
 export const editModule = async (req, res) => {
   try {
@@ -72,11 +72,11 @@ export const editModule = async (req, res) => {
     return res
       .status(200)
       .json({ module, message: "Module updated successfully." });
-  } catch (error) {
-    console.log(error);
-    return res.status(500).json({ message: "Failed to update module" });
-  }
-};
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Failed to update module" });
+    }
+  };
 
 // Only remove the module if it has no lectures
 export const removeModule = async (req, res) => {
@@ -103,7 +103,7 @@ export const removeModule = async (req, res) => {
 
     return res.status(200).json({ message: "Module deleted successfully." });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     return res.status(500).json({ message: "Failed to delete module" });
   }
 };
@@ -137,7 +137,7 @@ export const createModuleLecture = async (req, res) => {
       .status(201)
       .json({ lecture, message: "Lecture created successfully." });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     return res.status(500).json({ message: "Failed to create lecture" });
   }
 };
@@ -149,14 +149,13 @@ export const getModuleLectures = async (req, res) => {
     if (!module) return res.status(404).json({ message: "Module not found" });
     return res.status(200).json({ lectures: module.lectures });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     return res.status(500).json({ message: "Failed to get lectures" });
   }
 };
 
 export const editModuleLecture = async (req, res) => {
-  // ── console.log the entire body for debugging
-  console.log("editModuleLecture(req.body) =", JSON.stringify(req.body));
+  // Debugging statement removed to avoid logging sensitive request data
 
   try {
     const { lectureTitle, videoInfo, preview } = req.body;
@@ -247,11 +246,11 @@ export const removeModuleLecture = async (req, res) => {
     }
 
     return res.status(200).json({ message: "Lecture removed successfully." });
-  } catch (error) {
-    console.log(error);
-    return res.status(500).json({ message: "Failed to remove lecture" });
-  }
-};
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Failed to remove lecture" });
+    }
+  };
 
 // Fixed: always return at least { videoUrl, publicId, preview }
 export const getModuleLectureVideoInfo = async (req, res) => {

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -192,7 +192,7 @@ export const logout = async (_, res) => {
         success: true,
       });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     return res.status(500).json({
       success: false,
       message: "Failed to logout",


### PR DESCRIPTION
## Summary
- clean up console.log calls in controllers
- use `console.error` for caught errors and drop debug logs

## Testing
- `npm --prefix server test` *(fails: cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684d46b630d88329b639d5134d2f5c8c