### PR TITLE
Use FRONTEND_URL for CORS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 PORT=3000
 MONGO_URI=mongodb://localhost:27017/knowbloom
 SECRET_KEY=your_jwt_secret
+# URL of the frontend application (used for CORS)
 FRONTEND_URL=https://knowbloom.onrender.com
 CLIENT_ID=your_google_client_id
 CLIENT_SECRET=your_google_client_secret

--- a/server/index.js
+++ b/server/index.js
@@ -21,6 +21,7 @@ connectDB();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const FRONTEND_URL = process.env.FRONTEND_URL;
 
 // Trust proxy for secure cookies
 app.set("trust proxy", 1);
@@ -28,7 +29,7 @@ app.set("trust proxy", 1);
 // CORS (must come before routes)
 app.use(
   cors({
-    origin: "https://knowbloom.onrender.com",
+    origin: FRONTEND_URL,
     credentials: true,
   })
 );


### PR DESCRIPTION
## Summary
- use `process.env.FRONTEND_URL` when configuring CORS
- document the new variable in `.env.example`

## Testing
- `npm test --prefix server` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684d4a73184c8329958f73d45b078a91