### PR TITLE
Add client environment example

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for KnowBloom client
+# Base URL of the API server used by the frontend
+VITE_API_URL=http://localhost:3000


### PR DESCRIPTION
## Summary
- add `.env.example` to client folder with VITE_API_URL hint

## Testing
- `npm test` *(fails: Cannot find package 'express')*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d4b8f9c1c83298051ccc9a02a941b