### PR TITLE
Configure CORS origin via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ MONGO_URI=mongodb://localhost:27017/knowbloom
 SECRET_KEY=your_jwt_secret
 # URL of the frontend application (used for CORS)
 FRONTEND_URL=https://knowbloom.onrender.com
+# Allowed CORS origin (defaults to FRONTEND_URL)
+ALLOWED_ORIGIN=https://knowbloom.onrender.com
 CLIENT_ID=your_google_client_id
 CLIENT_SECRET=your_google_client_secret
 EMAIL_USER=your_email@gmail.com

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,8 @@ connectDB();
 const app = express();
 const PORT = process.env.PORT || 3000;
 const FRONTEND_URL = process.env.FRONTEND_URL;
+const ALLOWED_ORIGIN =
+  process.env.ALLOWED_ORIGIN || FRONTEND_URL || "http://localhost:5173";
 
 // Trust proxy for secure cookies
 app.set("trust proxy", 1);
@@ -29,7 +31,7 @@ app.set("trust proxy", 1);
 // CORS (must come before routes)
 app.use(
   cors({
-    origin: FRONTEND_URL,
+    origin: ALLOWED_ORIGIN,
     credentials: true,
   })
 );


### PR DESCRIPTION
## Summary
- let CORS origin be set through a new `ALLOWED_ORIGIN` variable
- document `ALLOWED_ORIGIN` in `.env.example`

## Testing
- `npm test` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684d4b91d8a483299a60c014a1fb50f5