### PR TITLE
Add policy pages

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -21,6 +21,11 @@ import EditProfile from "@/components/EditProfile";
 
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/reset";
+import About from "./pages/About";
+import Contact from "./pages/Contact";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
+import TermsOfService from "./pages/TermsOfService";
+import RefundPolicy from "./pages/RefundPolicy";
 
 import LectureTab from "./pages/instructor/lecture/LectureTab";
 import Dashboard from "./pages/instructor/Dashboard";
@@ -86,6 +91,11 @@ const appRouter = createBrowserRouter([
       { path: ":username/edit-profile", element: <EditProfile /> },
       { path: "course-detail/:courseId", element: <CourseDetail /> },
       { path: "search", element: <SearchPage /> },
+      { path: "about", element: <About /> },
+      { path: "contact", element: <Contact /> },
+      { path: "privacy-policy", element: <PrivacyPolicy /> },
+      { path: "terms", element: <TermsOfService /> },
+      { path: "refund-policy", element: <RefundPolicy /> },
       {
         path: "course-progress/:courseId",
         element: (

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -167,6 +167,14 @@ const Footer = () => {
                   Terms of Service
                 </Link>
               </li>
+              <li>
+                <Link
+                  to="/refund-policy"
+                  className="text-sm hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors"
+                >
+                  Refund Policy
+                </Link>
+              </li>
             </ul>
           </div>
         </div>

--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const About = () => (
+  <div className="max-w-3xl mx-auto px-4 py-8">
+    <h1 className="text-3xl font-bold mb-4 text-gray-800 dark:text-white">About KnowBloom</h1>
+    <p className="text-gray-700 dark:text-gray-300 mb-2">
+      KnowBloom is an online learning platform focused on delivering hands-on, industry relevant courses.
+    </p>
+    <p className="text-gray-700 dark:text-gray-300 mb-2">
+      Our mission is to empower learners around the world with practical skills that help them advance their careers and personal goals.
+    </p>
+    <p className="text-gray-700 dark:text-gray-300">
+      We are constantly expanding our catalog and improving the learning experience for our community.
+    </p>
+  </div>
+);
+
+export default About;

--- a/client/src/pages/Contact.jsx
+++ b/client/src/pages/Contact.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const Contact = () => (
+  <div className="max-w-3xl mx-auto px-4 py-8">
+    <h1 className="text-3xl font-bold mb-4 text-gray-800 dark:text-white">Contact Us</h1>
+    <p className="text-gray-700 dark:text-gray-300 mb-2">If you have any questions or feedback, feel free to reach out to us.</p>
+    <p className="text-gray-700 dark:text-gray-300">Email: <a href="mailto:support@knowbloom.com" className="text-cyan-600 dark:text-cyan-400">support@knowbloom.com</a></p>
+  </div>
+);
+
+export default Contact;

--- a/client/src/pages/PrivacyPolicy.jsx
+++ b/client/src/pages/PrivacyPolicy.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const PrivacyPolicy = () => (
+  <div className="max-w-3xl mx-auto px-4 py-8">
+    <h1 className="text-3xl font-bold mb-4 text-gray-800 dark:text-white">Privacy Policy</h1>
+    <p className="text-gray-700 dark:text-gray-300 mb-2">We respect your privacy and only collect information necessary to provide our services.</p>
+    <p className="text-gray-700 dark:text-gray-300">Please review this policy regularly to stay informed of any updates.</p>
+  </div>
+);
+
+export default PrivacyPolicy;

--- a/client/src/pages/RefundPolicy.jsx
+++ b/client/src/pages/RefundPolicy.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const RefundPolicy = () => (
+  <div className="max-w-3xl mx-auto px-4 py-8">
+    <h1 className="text-3xl font-bold mb-4 text-gray-800 dark:text-white">Refund Policy</h1>
+    <p className="text-gray-700 dark:text-gray-300 mb-2">If you are not satisfied with a purchase, you may request a refund within 30 days.</p>
+    <p className="text-gray-700 dark:text-gray-300">Contact our support team for assistance with refund requests.</p>
+  </div>
+);
+
+export default RefundPolicy;

--- a/client/src/pages/TermsOfService.jsx
+++ b/client/src/pages/TermsOfService.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const TermsOfService = () => (
+  <div className="max-w-3xl mx-auto px-4 py-8">
+    <h1 className="text-3xl font-bold mb-4 text-gray-800 dark:text-white">Terms of Service</h1>
+    <p className="text-gray-700 dark:text-gray-300 mb-2">By using KnowBloom you agree to abide by our terms of service.</p>
+    <p className="text-gray-700 dark:text-gray-300">These terms may change from time to time, so please check back periodically.</p>
+  </div>
+);
+
+export default TermsOfService;


### PR DESCRIPTION
## Summary
- create informational pages: About, Contact, Privacy, Terms, and Refund Policy
- register new pages in the router
- link Refund Policy from the footer

## Testing
- `npm test` *(fails: cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684ea0812edc83298637d6548e36f6f9