### PR TITLE
Add login failure page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -26,6 +26,7 @@ import Contact from "./pages/Contact";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import RefundPolicy from "./pages/RefundPolicy";
+import LoginFailed from "./pages/LoginFailed";
 
 import LectureTab from "./pages/instructor/lecture/LectureTab";
 import Dashboard from "./pages/instructor/Dashboard";
@@ -69,6 +70,7 @@ const appRouter = createBrowserRouter([
           </GuestOnlyRoute>
         ),
       },
+      { path: "login/failed", element: <LoginFailed /> },
       {
         path: "my-learning",
         element: (

--- a/client/src/pages/LoginFailed.jsx
+++ b/client/src/pages/LoginFailed.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+const LoginFailed = () => (
+  <div className="max-w-md mx-auto text-center py-20">
+    <h1 className="text-3xl font-semibold mb-4 text-gray-800 dark:text-white">Login Failed</h1>
+    <p className="text-gray-700 dark:text-gray-300 mb-6">
+      We couldn't sign you in. Please try again.
+    </p>
+    <Button asChild>
+      <Link to="/login">Back to Login</Link>
+    </Button>
+  </div>
+);
+
+export default LoginFailed;

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -49,6 +49,7 @@ router.get(
   "/google/callback",
   passport.authenticate("google", {
     successRedirect: process.env.FRONTEND_URL,
+    // Redirects to a client route showing the login failure message
     failureRedirect: "/login/failed",
   })
 );


### PR DESCRIPTION
## Summary
- show login error message in the client application
- register the `/login/failed` route in React
- note login failure redirect in server route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684ea2a058b48329a0a3267683eb66f5