### PR TITLE
Add PageNotFound component

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -27,6 +27,7 @@ import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import RefundPolicy from "./pages/RefundPolicy";
 import LoginFailed from "./pages/LoginFailed";
+import PageNotFound from "./pages/PageNotFound";
 
 import LectureTab from "./pages/instructor/lecture/LectureTab";
 import Dashboard from "./pages/instructor/Dashboard";
@@ -51,7 +52,7 @@ const appRouter = createBrowserRouter([
   {
     path: "/",
     element: <MainLayout />,
-    errorElement: <div className="text-center py-20">404 - Page Not Found</div>,
+    errorElement: <PageNotFound />,
     children: [
       {
         index: true,

--- a/client/src/pages/PageNotFound.jsx
+++ b/client/src/pages/PageNotFound.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+const PageNotFound = () => (
+  <div className="max-w-md mx-auto text-center py-20">
+    <h1 className="text-3xl font-semibold mb-4 text-gray-800 dark:text-white">
+      Page Not Found
+    </h1>
+    <p className="text-gray-700 dark:text-gray-300 mb-6">
+      The page you're looking for doesn't exist.
+    </p>
+    <Button asChild>
+      <Link to="/">Go Home</Link>
+    </Button>
+  </div>
+);
+
+export default PageNotFound;


### PR DESCRIPTION
## Summary
- add a `PageNotFound` page for 404s
- use `PageNotFound` in App router

## Testing
- `npm test` *(fails: Cannot find package 'express')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ea4faff948329b7f6db60208987f2