### PR TITLE
Add generic 500 error page with API redirect

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -27,6 +27,7 @@ import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
 import RefundPolicy from "./pages/RefundPolicy";
 import LoginFailed from "./pages/LoginFailed";
+import ServerError from "./pages/ServerError";
 
 import LectureTab from "./pages/instructor/lecture/LectureTab";
 import Dashboard from "./pages/instructor/Dashboard";
@@ -139,6 +140,10 @@ const appRouter = createBrowserRouter([
         element: <InstructorAnnouncements />,
       },
     ],
+  },
+  {
+    path: "/server-error",
+    element: <ServerError />,
   },
 ]);
 

--- a/client/src/features/api/authApi.js
+++ b/client/src/features/api/authApi.js
@@ -1,12 +1,13 @@
 // src/features/api/authApi.js
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { createApi } from "@reduxjs/toolkit/query/react";
+import { createCustomBaseQuery } from "./customBaseQuery";
 import { userLoggedIn, userLoggedOut } from "../authSlice";
 
 const USER_API = `${import.meta.env.VITE_API_URL}/api/v1/user`;
 
 export const authApi = createApi({
   reducerPath: "authApi",
-  baseQuery: fetchBaseQuery({
+  baseQuery: createCustomBaseQuery({
     baseUrl: USER_API,
     credentials: "include",
     prepareHeaders: (headers) => {

--- a/client/src/features/api/courseApi.js
+++ b/client/src/features/api/courseApi.js
@@ -1,4 +1,5 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { createApi } from "@reduxjs/toolkit/query/react";
+import { createCustomBaseQuery } from "./customBaseQuery";
 
 const COURSE_API = `${import.meta.env.VITE_API_URL}/api/v1/course`;
 
@@ -13,7 +14,7 @@ export const courseApi = createApi({
     "Students",
     "Announcement",
   ],
-  baseQuery: fetchBaseQuery({
+  baseQuery: createCustomBaseQuery({
     baseUrl: COURSE_API,
     credentials: "include",
   }),

--- a/client/src/features/api/courseProgressApi.js
+++ b/client/src/features/api/courseProgressApi.js
@@ -1,12 +1,13 @@
 // src/features/api/courseProgressApi.js
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { createApi } from "@reduxjs/toolkit/query/react";
+import { createCustomBaseQuery } from "./customBaseQuery";
 
 const COURSE_PROGRESS_API = `${import.meta.env.VITE_API_URL}/api/v1/progress`;
 
 
 export const courseProgressApi = createApi({
   reducerPath: "courseProgressApi",
-  baseQuery: fetchBaseQuery({
+  baseQuery: createCustomBaseQuery({
     baseUrl: COURSE_PROGRESS_API,
     credentials: "include",
   }),

--- a/client/src/features/api/customBaseQuery.js
+++ b/client/src/features/api/customBaseQuery.js
@@ -1,0 +1,12 @@
+import { fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const createCustomBaseQuery = (options) => {
+  const baseQuery = fetchBaseQuery(options);
+  return async (args, api, extra) => {
+    const result = await baseQuery(args, api, extra);
+    if (result.error && result.error.status >= 500) {
+      window.location.href = "/server-error";
+    }
+    return result;
+  };
+};

--- a/client/src/features/api/purchaseApi.js
+++ b/client/src/features/api/purchaseApi.js
@@ -1,12 +1,13 @@
 // src/features/api/purchaseApi.js
 
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { createApi } from "@reduxjs/toolkit/query/react";
+import { createCustomBaseQuery } from "./customBaseQuery";
 
 const COURSE_PURCHASE_API = `${import.meta.env.VITE_API_URL}/api/v1/purchase`;
 
 export const purchaseApi = createApi({
   reducerPath: "purchaseApi",
-  baseQuery: fetchBaseQuery({
+  baseQuery: createCustomBaseQuery({
     baseUrl: COURSE_PURCHASE_API,
     credentials: "include",
   }),

--- a/client/src/pages/ServerError.jsx
+++ b/client/src/pages/ServerError.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const ServerError = () => (
+  <div className="text-center py-20">
+    <h1 className="text-4xl font-bold mb-4">Something went wrong</h1>
+    <p className="text-gray-700 dark:text-gray-300">
+      An unexpected server error occurred. Please try again later.
+    </p>
+  </div>
+);
+
+export default ServerError;

--- a/server/index.js
+++ b/server/index.js
@@ -84,7 +84,7 @@ app.use(express.static(path.join(__dirname, "../client/dist")));
 // Global error handlers
 app.use((err, req, res, next) => {
   console.error("Global error:", err);
-  res.status(500).json({ message: "Something went wrong" });
+  res.status(500).json({ message: "Something went wrong", code: "SERVER_ERROR" });
 });
 app.use((req, res) => {
   res.status(404).json({ message: "Route not found" });


### PR DESCRIPTION
## Summary
- add a `ServerError` page
- redirect to the page from API slices when a 500+ response is returned
- expose helper `createCustomBaseQuery` used by all API slices
- route `/server-error` in app router
- include error code in the server's global error handler

## Testing
- `npm test` *(fails: Cannot find package 'express')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ea4fda2dc832995a05d621a89f630