### PR TITLE
Update frontend URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,9 @@ PORT=3000
 MONGO_URI=mongodb://localhost:27017/knowbloom
 SECRET_KEY=your_jwt_secret
 # URL of the frontend application (used for CORS)
-FRONTEND_URL=https://knowbloom.onrender.com
+FRONTEND_URL=https://know-bloomvercel.vercel.app
 # Allowed CORS origin (defaults to FRONTEND_URL)
-ALLOWED_ORIGIN=https://knowbloom.onrender.com
+ALLOWED_ORIGIN=https://know-bloomvercel.vercel.app
 CLIENT_ID=your_google_client_id
 CLIENT_SECRET=your_google_client_secret
 EMAIL_USER=your_email@gmail.com

--- a/server/controllers/coursePurchase.controller.js
+++ b/server/controllers/coursePurchase.controller.js
@@ -64,8 +64,8 @@ export const createCheckoutSession = async (req, res) => {
       currency: order.currency,
       courseTitle: course.courseTitle,
       courseThumbnail: course.courseThumbnail,
-      successUrl: `https://knowbloom.onrender.com/course-progress/${courseId}`,
-      failureUrl: `https://knowbloom.onrender.com/course-detail/${courseId}`,
+      successUrl: `https://know-bloomvercel.vercel.app/course-progress/${courseId}`,
+      failureUrl: `https://know-bloomvercel.vercel.app/course-detail/${courseId}`,
     });
   } catch (err) {
     console.error("createCheckoutSession error:", err);

--- a/server/index.js
+++ b/server/index.js
@@ -29,7 +29,7 @@ app.set("trust proxy", 1);
 // CORS
 app.use(
   cors({
-    origin: process.env.FRONTEND_URL || "https://knowbloom.onrender.com",
+    origin: process.env.FRONTEND_URL || "https://know-bloomvercel.vercel.app",
     credentials: true,
   })
 );

--- a/server/utils/email.js
+++ b/server/utils/email.js
@@ -8,7 +8,7 @@ import { log } from "./logger.js";
 export const EMAIL_USER = process.env.EMAIL_USER;
 export const EMAIL_PASS = process.env.EMAIL_PASS;
 export const USER_NAME = process.env.USER_NAME || "KnowBloom Team";
-const LOGO_URL = "https://knowbloom.onrender.com/logo.png";
+const LOGO_URL = "https://know-bloomvercel.vercel.app/logo.png";
 
 // create a single Gmail transporter
 const transporter = nodemailer.createTransport({


### PR DESCRIPTION
## Summary
- update allowed frontend origin
- adjust purchase flow redirect URLs
- fix logo links for email templates
- set new defaults in `.env.example`

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_684ef5801e0c8329af041f3549b3cf92